### PR TITLE
Added a variable to specify the build directory for out of source build.

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -42,6 +42,11 @@
   :type 'boolean
   :group 'helm-make)
 
+(defcustom helm-make-build-dir ""
+  "Specify a build directory for out of source build."
+  :type '(string)
+  :group 'helm-make)
+
 (defun helm-make-action (target)
   "Make TARGET."
   (compile (format "make %s" target)))
@@ -92,7 +97,8 @@ If makefile is specified use it as path to Makefile"
   (require 'projectile)
   (let ((makefile (expand-file-name
                    "Makefile"
-                   (projectile-project-root))))
+		   (concat (projectile-project-root) helm-make-build-dir))))
+
     (helm-make
      (and (file-exists-p makefile) makefile))))
 


### PR DESCRIPTION
Hi,

as it is common practice to build a cmake based project out of source, usually in a directory
called `build` or `release` for release builds.
I thought it would be nice to make it possible to tell `helm-make` where the main Makefile lies. 

I'm looking forward to here about your thoughts.

Christian 

 
PS: It's my first time to open a pull request (contribute to an existing project that way). So be patient with me if I did something wrong. :-)
