### PR TITLE
Wrong function call in function helm-make-projectile

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -42,6 +42,11 @@
   :type 'boolean
   :group 'helm-make)
 
+(defcustom helm-make-build-dir ""
+  "Specify a build directory for out of source build."
+  :type '(string)
+  :group 'helm-make)
+
 (defun helm-make-action (target)
   "Make TARGET."
   (compile (format "make %s" target)))
@@ -92,7 +97,8 @@ If makefile is specified use it as path to Makefile"
   (require 'projectile)
   (let ((makefile (expand-file-name
                    "Makefile"
-                   (projectile-project-root))))
+		   (concat (projectile-project-root) helm-make-build-dir))))
+
     (helm-make
      (and (file-exists-p makefile) makefile))))
 

--- a/helm-make.el
+++ b/helm-make.el
@@ -127,7 +127,7 @@ ARG specifies the number of cores."
                    "Makefile"
 		   (concat (projectile-project-root) helm-make-build-dir))))
 
-    (helm-make
+    (helm--make
      (if (file-exists-p makefile) makefile "Makefile"))))
 
 (provide 'helm-make)


### PR DESCRIPTION
Call `helm--make` in function `helm-make-projectile` instead of `helm-make`.