### PR TITLE
Added variable which stores the recently used targets

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -42,6 +42,11 @@
   :type 'boolean
   :group 'helm-make)
 
+(defcustom helm-make-build-dir ""
+  "Specify a build directory for out of source build."
+  :type '(string)
+  :group 'helm-make)
+
 (defun helm-make-action (target)
   "Make TARGET."
   (compile (format "make %s" target)))
@@ -92,7 +97,8 @@ If makefile is specified use it as path to Makefile"
   (require 'projectile)
   (let ((makefile (expand-file-name
                    "Makefile"
-                   (projectile-project-root))))
+		   (concat (projectile-project-root) helm-make-build-dir))))
+
     (helm-make
      (and (file-exists-p makefile) makefile))))
 

--- a/helm-make.el
+++ b/helm-make.el
@@ -127,7 +127,7 @@ ARG specifies the number of cores."
                    "Makefile"
 		   (concat (projectile-project-root) helm-make-build-dir))))
 
-    (helm-make
+    (helm--make
      (if (file-exists-p makefile) makefile "Makefile"))))
 
 (provide 'helm-make)

--- a/helm-make.el
+++ b/helm-make.el
@@ -123,7 +123,7 @@ The path should be relative to the project root."
 				 :initial-input (car helm-make-recent-target-list)
 				 :history 'helm-make-recent-target-list
 				 :preselect (car helm-make-recent-target-list)
-				 :action 'helm-make-action)))
+				 :action 'helm-make-action))
 		      (ido
 		       (when (setq target (ido-completing-read "Target: "
 							       targets nil nil

--- a/helm-make.el
+++ b/helm-make.el
@@ -52,6 +52,9 @@ The path should be relative to the project root."
 (defvar helm-make-command nil
   "Store the make command.")
 
+(defvar helm-make-recent-target-list nil
+  "Holds the recently used targets.")
+
 (defun helm-make-action (target)
   "Make TARGET."
   (compile (format helm-make-command target)))
@@ -102,18 +105,32 @@ The path should be relative to the project root."
                       (unless (string-match "^\\." str)
                         (push str targets))))
                   (setq targets (nreverse targets))
-                  (cl-case helm-make-completion-method
-                    (helm
-                     (helm :sources
-                           `((name . "Targets")
-                             (candidates . ,targets)
-                             (action . helm-make-action))))
-                    (ivy
-                     (when (setq target (ivy-read "Target: " targets))
-                       (helm-make-action target)))
-                    (ido
-                     (when (setq target (ido-completing-read "Target: " targets))
-                       (helm-make-action target))))))))
+		  (delete-dups helm-make-recent-target-list)
+		  (let ((default-target-list
+			  (delete (car helm-make-recent-target-list) helm-make-recent-target-list)))
+		    (cl-case helm-make-completion-method
+		      (helm
+		       (helm :sources
+			     `((name . "Targets")
+			       (candidates . ,targets)
+			       (action . helm-make-action))
+			     :input (car helm-make-recent-target-list)
+			     :history 'helm-make-recent-target-list
+			     :default default-target-list))
+		      (ivy
+		       (ivy-read "Target: "
+				 targets
+				 :initial-input (car helm-make-recent-target-list)
+				 :history 'helm-make-recent-target-list
+				 :preselect (car helm-make-recent-target-list)
+				 :action 'helm-make-action)))
+		      (ido
+		       (when (setq target (ido-completing-read "Target: "
+							       targets nil nil
+							       (car helm-make-recent-target-list)
+							       'helm-make-recent-target-list
+							       default-target-list))
+			 (helm-make-action target)))))))))
       (error "No Makefile in %s" default-directory))))
 
 ;;;###autoload


### PR DESCRIPTION
Hey Oleh Krehel,

I added a variable (`helm-make-recent-target-list`) which holds a list of the recently used targets. 
This variable is used for the various completion backends (helm/ivy/ido)

To get the next target stored in the list one has to type:
* **Helm** -> M-n
* **Ivy**     -> M-p
* **Ido**    -> M-p

Let me know what you think.

Regards,
Christian

PS: I will create another pull request, as I have changed also the functionality of the function
`helm-make-projectile`. 
After the changes, it will look first in the directory `helm-make-build-dir` for a makefile, when non-nil. Followed by `projectile-project-root` and `projectile-project-root/build`. 

Why should we look by default in `projectile-project-root/build`? Well, because it is common to build 
CMake/Autotools, (and probably some more), based project in a different directory, usually `build`.

