### PR TITLE
Better target parsing.

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -100,16 +100,19 @@ makefile."
                buffers)))
           (with-helm-default-directory (file-name-directory file)
               (with-temp-buffer
-                (insert-file-contents file)
+                (insert (shell-command-to-string "make -qp"))
                 (goto-char (point-min))
-                (let (targets target)
-                  (while (re-search-forward "^\\([^: \n]+\\):" nil t)
+                (let (targets target prev-line)
+                  (while (re-search-forward "^\\([a-zA-Z0-9][^$#\/\t=]*\\):\\([^=]\\|$\\)" nil t)
+		    (forward-line -2)
+		    (setq prev-line (buffer-substring (line-beginning-position) (line-end-position)))
+		    (forward-line 3)
                     (let ((str (match-string 1)))
-                      (unless (string-match "^\\." str)
+                      (unless (string-match "^# Not a target:" prev-line)
                         (push str targets))))
+		  (delete-dups targets)
                   (setq targets (nreverse targets))
-                  (setq helm-make-target-history
-                        (delete-dups helm-make-target-history))
+		  (delete-dups helm-make-target-history)
                   (cl-case helm-make-completion-method
                     (helm
                      (helm :sources

--- a/helm-make.el
+++ b/helm-make.el
@@ -31,7 +31,7 @@
 ;;; Code:
 
 (require 'helm)
-(require 'helm-match-plugin)
+(require 'helm-multi-match)
 
 (defgroup helm-make nil
   "Select a Makefile target with helm."


### PR DESCRIPTION
Use make's output of `make -qp` to retrieve the available targets.
When we parse make's database, rather, than the Makefile directly, we
get the precise list of targets available.

The previous method delivered inaccurate results. Consider the following
`make` snippet.

``` make
TARGETS = server client

$(TARGETS): prerequisites
	    some recipe
```

`helm-make` would display

``` bash
$(TARGETS)
```

instead of

``` bash
server
client
```

It gets even worse, when the project Makefile's are written
non-recursively (The correct way). In this case, the targets, included
from the sub-module, would not be displayed at all.


INFO:
I'm not quite sure if there is a better solution (function) to get the previous line of the regex match.


Christian