### PR TITLE
Improve make -qp once more.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,12 @@ directory will be saved.
 #### `helm-make-projectile`
 
 This is a `helm-make` called with `(projectile-project-root)` as base directory.
+
+
+#### `helm-make-list-target-method`
+
+What method should be used to parse the Makefile. The default value is
+`default`, which is a pure elisp solution, but falls a bit short when the
+Makefile includes other Makefile's. The second option is `qp`, it is much more
+accurate, as it uses the database produced by make to extract the
+targets. But could be a bit slower when the database produced by make is large.

--- a/helm-make.el
+++ b/helm-make.el
@@ -79,16 +79,18 @@ makefile."
    "Makefile"))
 
 (defun helm--make-target-list-qp (makefile)
-  "Return sorted target list for MAKEFILE using \"make -qp\"."
+  "Return sorted target list for MAKEFILE using \"make -nqp\"."
   (let ((default-directory (file-name-directory
                             (expand-file-name makefile)))
         targets target)
     (with-temp-buffer
-      (insert (shell-command-to-string "make -qp"))
+      (insert
+       (shell-command-to-string
+        "make -nqp __BASH_MAKE_COMPLETION__=1 .DEFAULT 2>/dev/null"))
       (goto-char (point-min))
       (unless (re-search-forward "^# Files" nil t)
-        (error "Unexpected \"make -qp\" output"))
-      (while (re-search-forward "^\\([^%$:\/#\n\t =]+\\):\\([^=]\\|$\\)" nil t)
+        (error "Unexpected \"make -nqp\" output"))
+      (while (re-search-forward "^\\([^%$:#\n\t ]+\\):\\([^=]\\|$\\)" nil t)
         (setq target (match-string 1))
         (unless (or (save-excursion
 		      (goto-char (match-beginning 0))


### PR DESCRIPTION
This should give us 98% to 99% accuracy even on the most complex
Makefiles.

I'm not sure, if I should also change the customize option, `make -qp` to `make -nqp`, as well as the symbol `qp` to `nqp` or just leave it as it is. 

In my opinion,  `qp` looks more natural. :-)

Christian