### PR TITLE
Cache targets; Make sorting optional via defcustom

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-###Description
+### Description
 
 A call to `helm-make` will give you a `helm` selection of this directory
 Makefile's targets. Selecting a target will call `compile` on it.
 You can cancel as usual with `C-g`.
 
-###Install
+### Install
 
 Just get it from [MELPA](http://melpa.org/).
 
@@ -12,18 +12,16 @@ The functions that this package provides are auto-loaded, so no
 additional setup is required. Unless you want to bind the functions to
 a key.
 
-###Additional stuff
+### Additional stuff
 
 #### `helm-make-do-save`
 
 If this is set to `t`, the currently visited files from Makefile's
 directory will be saved.
 
-
 #### `helm-make-projectile`
 
 This is a `helm-make` called with `(projectile-project-root)` as base directory.
-
 
 #### `helm-make-list-target-method`
 
@@ -32,3 +30,25 @@ What method should be used to parse the Makefile. The default value is
 Makefile includes other Makefile's. The second option is `qp`, it is much more
 accurate, as it uses the database produced by make to extract the
 targets. But could be a bit slower when the database produced by make is large.
+
+#### `helm-make-build-dir`
+
+An additional directory, relative to `projectile-project-root`, where
+`helm-make-projectile` will search for a valid Makefile. A valid Makefile is
+one that GNU make looks after, i.e. the name of the Makefile must be one of
+Makefile, makefile or GNUmakefile to be valid.
+
+#### `helm-make-sort-targets`
+
+If this is set to `t`, sort the targets before calling the completion method.
+By default it is set to nil, if you are setting it to `t`, and you encounter
+longer delays before the targets are displayed, try to set this back to nil.
+This, however, might only be the case, if the Makefile contains thousand of
+targets.
+
+#### `helm-make-cache-targets`
+
+If this is set to `t`, cache the targets. Next time when you call
+`helm-make(-projectile)` for the same Makefile, and the modification time of
+the Makefile has not changed meanwhile, reuse the cached targets.
+It is set to `nil` by default.


### PR DESCRIPTION
Hey abo-abo,

I played a bit around with helm-make, and added some more goodies (at least I think so:-).

> Added defcustom to cache targets of Makefile, and store the Makefile
> file path along with its current modification time, next time check
> if we need to reparse the Makefile, if not, reuse the cached targets.
> 
> Added defcustom to sort targets as a final step. I added it mainly
> because sorting could cause significant performance problems. E.g. when
> using helm-make(-projectile) for buildroot, which contains ~60,000
> targets, it took ~1 min 30 sec until the targets where displayed,
> without sorting it took ~10 sec.
> 
> Search for GNUmakefile, makefile and Makefile, those are the Makefile
> names GNU make understands.
> https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html
> 
> Other changes:
> - Silent byte compiler.
> - Update README to match the latest changes.
> - Increase version number
> - Move defcustom's together

I didn't update the README yet, I thought before I will do this it would be nice, if you can review my commit so I can change what you don't like. If you are happy with that changes I will update the README, and force the next push.

Also, I would like to point out that I'm still not happy with the result of `helm--make-target-list-qp`, cause there are still to many false-positive targets included. I thought about adding a defcustom holding a regex exclude pattern, what do you think? I'll also try to improve the heuristic algorithm to decrease the false-positives. E.g. in buildroot, bash-completion gives ~52,000 targets, while `helm--make-target-list-qp` gives ~60,000 targets.

regards,
Christian
