### PR TITLE
Introduce new defcustom: helm-make-executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ If this is set to `t`, cache the targets. Next time when you call
 `helm-make(-projectile)` for the same Makefile, and the modification time of
 the Makefile has not changed meanwhile, reuse the cached targets.
 It is set to `nil` by default.
+
+#### `helm-make-executable`
+
+You can customize executable of make command by changing this variable. Helpful
+for implementing remote compiling.

--- a/helm-make.el
+++ b/helm-make.el
@@ -76,6 +76,11 @@ You can reset the cache by calling `helm-make-reset-db'."
   :type 'boolean
   :group 'helm-make)
 
+(defcustom helm-make-executable "make"
+  "Store the name of make executable."
+  :type '(string)
+  :group 'helm-make)
+
 (defvar helm-make-command nil
   "Store the make command.")
 
@@ -102,7 +107,7 @@ An exception is \"GNUmakefile\", only GNU make unterstand it.")
   "Call \"make -j ARG target\". Target is selected with completion."
   (interactive "p")
   "make %s"
-  (setq helm-make-command (format "make -j%d %%s" arg))
+  (setq helm-make-command (format "%s -j%d %%s" helm-make-executable arg))
   (let ((makefile (helm--make-makefile-exists default-directory)))
     (if makefile
         (helm--make makefile)
@@ -269,7 +274,7 @@ You can specify an additional directory to search for a makefile by
 setting the buffer local variable `helm-make-build-dir'."
   (interactive "p")
   (require 'projectile)
-  (setq helm-make-command (format "make -j%d %%s" arg))
+  (setq helm-make-command (format "%s -j%d %%s" helm-make-executable arg))
   (let ((makefile (helm--make-makefile-exists
                    (projectile-project-root)
                    (if (and (stringp helm-make-build-dir)


### PR DESCRIPTION
This allows users of helm-make customize make executable name.

The main reason of this change is to allow use some other programs instead of make. I'm currently use simple perl script that performs rsync to some build machine and then executes ssh command on remote mode to run make on some other node.