### PR TITLE
NEW add comint and named-buffer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,14 @@ It is set to `nil` by default.
 
 You can customize executable of make command by changing this variable. Helpful
 for implementing remote compiling.
+
+#### `helm-make-named-buffer`
+
+When setting helm-make-named-buffer to `t` all make buffers will be named based
+on their make target. e.g. \*Helm-Make all\* for `make all`. This is useful if
+you want to run multiple make targets at the same time.
+
+#### `helm-make-comint`
+
+When setting helm-make-comint to `t` helm-make will use Comint mode instead of
+Compilation mode. This is useful if you want to interact with the make buffer.

--- a/helm-make.el
+++ b/helm-make.el
@@ -85,6 +85,14 @@ You can reset the cache by calling `helm-make-reset-db'."
   "When non-nil, don't allow selecting a target that's not on the list."
   :type 'boolean)
 
+(defcustom helm-make-named-buffer nil
+  "When non-nil, name compilation buffer based on make target."
+  :type 'boolean)
+
+(defcustom helm-make-comint nil
+  "When non-nil, run helm-make in Comint mode instead of Compilation mode."
+  :type 'boolean)
+
 (defvar helm-make-command nil
   "Store the make command.")
 
@@ -97,7 +105,20 @@ An exception is \"GNUmakefile\", only GNU make unterstand it.")
 
 (defun helm--make-action (target)
   "Make TARGET."
-  (compile (format helm-make-command target)))
+  (let* ((make-command (format helm-make-command target))
+         (compile-buffer (compile make-command helm-make-comint)))
+    (when helm-make-named-buffer
+      (helm--make-rename-buffer compile-buffer target))))
+
+(defun helm--make-rename-buffer (buffer target)
+  "Rename the compilation BUFFER based on the make TARGET."
+  (let ((buffer-name (format "*Helm-Make %s*" target)))
+    (when (get-buffer-window buffer-name)
+      (delete-window (get-buffer-window buffer-name)))
+    (when (get-buffer buffer-name)
+      (kill-buffer buffer-name))
+    (with-current-buffer compile-buffer
+      (rename-buffer buffer-name))))
 
 (defcustom helm-make-completion-method 'helm
   "Method to select a candidate from a list of strings."


### PR DESCRIPTION
Hi
I've added two new options in this PR.

1. Named buffers. This allows Helm-make to name the compilation buffers based on their target. For example if you run helm-make `all` the buffer will be named `*Helm-Make all*`. This is useful if you run multiple make targets at the same time.

2. Comint mode. This will allow you to run make targets in Comint mode instead of compilation mode. This is useful if your make targets accept user input.