### PR TITLE
Fix issue #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,8 @@ you want to run multiple make targets at the same time.
 
 When setting helm-make-comint to `t` helm-make will use Comint mode instead of
 Compilation mode. This is useful if you want to interact with the make buffer.
+
+#### `helm-make-fuzzy-matching`
+
+When this variable is non-nil, fuzzy matching will be enabled helm make
+targets buffer.

--- a/helm-make.el
+++ b/helm-make.el
@@ -31,7 +31,6 @@
 ;;; Code:
 
 (require 'helm)
-(require 'helm-multi-match)
 
 (declare-function ivy-read "ext:ivy")
 
@@ -91,6 +90,10 @@ You can reset the cache by calling `helm-make-reset-db'."
 
 (defcustom helm-make-comint nil
   "When non-nil, run helm-make in Comint mode instead of Compilation mode."
+  :type 'boolean)
+
+(defcustom helm-make-fuzzy-matching nil
+  "When non-nil, enable fuzzy matching in helm make target(s) buffer."
   :type 'boolean)
 
 (defvar helm-make-command nil
@@ -264,13 +267,13 @@ and cache targets of MAKEFILE, if `helm-make-cache-targets' is t."
     (delete-dups helm-make-target-history)
     (cl-case helm-make-completion-method
       (helm
-       (helm :sources
-             `((name . "Targets")
-               (candidates . ,targets)
-               (action . helm--make-action))
+       (helm :sources (helm-build-sync-source "Targets"
+                        :candidates 'targets
+                        :fuzzy-match helm-make-fuzzy-matching
+                        :action 'helm--make-action)
              :history 'helm-make-target-history
              :preselect (when helm-make-target-history
-                          (format "^%s$" (car helm-make-target-history)))))
+                          (car helm-make-target-history))))
       (ivy
        (ivy-read "Target: "
                  targets


### PR DESCRIPTION
Use the macro `helm-build-sync-sources` to create _sources_ properties for `helm`. Also, add a new `defcustom` to allow enabling fuzzy matching in helm make targets buffer.