### PR TITLE
Fix issue #33

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -343,7 +343,7 @@ setting the buffer local variable `helm-make-build-dir'."
         (error "No Makefile found for project %s" (projectile-project-root))
       (setq helm-make-command (format (concat "%s -C %s " helm-make-arguments " %%s")
                                       helm-make-executable
-                                      (replace-regexp-in-string "/\\(scp\\|ssh\\).+?:" ""
+                                      (replace-regexp-in-string "^/\\(scp\\|ssh\\).+?:" ""
                                                                 (file-name-directory makefile))
                                       arg))
       (helm--make makefile))))

--- a/helm-make.el
+++ b/helm-make.el
@@ -343,7 +343,8 @@ setting the buffer local variable `helm-make-build-dir'."
         (error "No Makefile found for project %s" (projectile-project-root))
       (setq helm-make-command (format (concat "%s -C %s " helm-make-arguments " %%s")
                                       helm-make-executable
-                                      (file-name-directory makefile)
+                                      (replace-regexp-in-string "/\\(scp\\|ssh\\).+?:" ""
+                                                                (file-name-directory makefile))
                                       arg))
       (helm--make makefile))))
 


### PR DESCRIPTION
When in tramp mode, files are prefixed with a line like
`/<connection>:<user>@<host>:` where `<connnection>` is `ssh` or `scp`.
The prefix can also be of the form` /<connection>:<Host>:` where
`<host>` is provided in .ssh/config. This change simply strips the
prefix if it is present so the make command will receive a well
formatted argument with its -C flag.