### PR TITLE
Fix some other small issues 

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -135,7 +135,7 @@ An exception is \"GNUmakefile\", only GNU make understands it.")
                        (or (> (length (helm-marked-candidates)) 1)
                            ;; Give single marked candidate precedence over current selection.
                            (unless (equal (car (helm-marked-candidates)) target)
-                             (setq target (car (helm-marked-candidates)))))
+                             (setq target (car (helm-marked-candidates))) nil))
                        (mapconcat 'identity (helm-marked-candidates) " ")))
          (make-command (format helm-make-command (or targets target)))
          (compile-buffer (compile make-command helm-make-comint)))

--- a/helm-make.el
+++ b/helm-make.el
@@ -33,6 +33,7 @@
 (require 'helm)
 
 (declare-function ivy-read "ext:ivy")
+(declare-function projectile-project-root "ext:projectile")
 
 (defgroup helm-make nil
   "Select a Makefile target with helm."
@@ -292,19 +293,20 @@ and cache targets of MAKEFILE, if `helm-make-cache-targets' is t."
          (entry (gethash makefile helm-make-db nil))
          (new-entry (make-helm-make-dbfile))
          (targets (cond
-                   ((and helm-make-cache-targets
-                         entry
-                         (equal modtime (helm-make-dbfile-modtime entry))
-                         (helm-make-dbfile-targets entry))
-                    (helm-make-dbfile-targets entry))
+                    ((and helm-make-cache-targets
+                          entry
+                          (equal modtime (helm-make-dbfile-modtime entry))
+                          (helm-make-dbfile-targets entry))
+                     (helm-make-dbfile-targets entry))
                    (t
                     (delete-dups
-                     (cond ((equal helm--make-build-system 'ninja)
-                            (helm--make-target-list-ninja makefile))
-                           ((equal helm-make-list-target-method 'qp)
-                            (helm--make-target-list-qp makefile))
-                           (t
-                            (helm--make-target-list-default makefile))))))))
+                     (cond
+                       ((equal helm--make-build-system 'ninja)
+                        (helm--make-target-list-ninja makefile))
+                       ((equal helm-make-list-target-method 'qp)
+                        (helm--make-target-list-qp makefile))
+                       (t
+                        (helm--make-target-list-default makefile))))))))
     (when helm-make-sort-targets
       (unless (and helm-make-cache-targets
                    entry


### PR DESCRIPTION
This PR will fix another compiler warning and indentation.

My recent change (96d7c66e49796fedf5e5f383769d96a456bc2134) had a small bug in it, `setq` will return the value set, and hence the `or` returns `t`, and the variable `targets` would be set even when there is only a single marked candidate.

Regarding the indentation after `cond`, how can I change mine to be 2 spaces by default, or did you just press 2 times space?
Thanks!
