### PR TITLE
Add new custom variable helm-make-niceness

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ When setting helm-make-named-buffer to `t` all make buffers will be named based
 on their make target. e.g. \*Helm-Make all\* for `make all`. This is useful if
 you want to run multiple make targets at the same time.
 
+#### `helm-make-named-buffer`
+
+When set to a non-zero value, invocations of make or ninja will run at this
+niceness level. Default is 0, i.e. don't nice make commands.
+
+
 #### `helm-make-comint`
 
 When setting helm-make-comint to `t` helm-make will use Comint mode instead of

--- a/helm-make.el
+++ b/helm-make.el
@@ -86,6 +86,11 @@ You can reset the cache by calling `helm-make-reset-db'."
   :type 'string
   :group 'helm-make)
 
+(defcustom helm-make-niceness 0
+  "When non-zero, run make jobs at this niceness level."
+  :type 'integer
+  :group 'helm-make)
+
 (defcustom helm-make-arguments "-j%d"
   "Pass these arguments to `helm-make-executable' or
 `helm-make-ninja-executable'. If `%d' is included, it will be substituted
@@ -166,7 +171,9 @@ and if the file exists 'make otherwise.")
 ARG should be universal prefix value passed to `helm-make' or
 `helm-make-projectile', and file is the path to the Makefile or the
 ninja.build file."
-  (format (concat "%s -C %s " helm-make-arguments " %%s")
+  (format (concat "%s%s -C %s " helm-make-arguments " %%s")
+          (if (eql helm-make-niceness 0) ""
+            (format "nice -n %d " helm-make-niceness))
           (cond
             ((equal helm--make-build-system 'ninja)
              helm-make-ninja-executable)


### PR DESCRIPTION
If helm-make-niceness is set to a non-zero value, helm-make commands will be wrapped in a call to nice. It's already possible to achieve this functionality by changing helm-make-executable or helm-make-ninja-executable, but I think this is useful enough to merit a new variable.