### PR TITLE
Fix whitespace in filename causing error in build

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -178,7 +178,7 @@ ninja.build file."
              helm-make-executable))
           (replace-regexp-in-string
            "^/\\(scp\\|ssh\\).+?:" ""
-           (file-name-directory file))
+           (shell-quote-argument (file-name-directory file)))
           arg))
 
 ;;;###autoload


### PR DESCRIPTION
Having a space in the path would not work when trying to build, quote it.