### PR TITLE
Quote the file path to support paths with spaces

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -167,7 +167,7 @@ and if the file exists 'make otherwise.")
 ARG should be universal prefix value passed to `helm-make' or
 `helm-make-projectile', and file is the path to the Makefile or the
 ninja.build file."
-  (format (concat "%s%s -C %s " helm-make-arguments " %%s")
+  (format (concat "%s%s -C '%s' " helm-make-arguments " %%s")
           (if (= helm-make-niceness 0)
               ""
             (format "nice -n %d " helm-make-niceness))


### PR DESCRIPTION
First, this change is 100% a guess, I don't know Emacs Lisp.

The error I ran into is that my Makefile lives in a directory path that has spaces.  So, when you try to run a target, you get something like:

```
make -C /Path/With a space/project/ -j1 link
make: *** /Path/With: No such file or directory.  Stop.

Compilation exited abnormally with code 2 at Tue Nov 13 21:40:40
```

Solution is just to add single quotes around the path.  I tried this out locally and it worked fine.  There might be a better way to escape shell args though in Emacs Lisp.