### PR TITLE
helm source include to stop invalid-function helm-build-sync-source e…

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -30,6 +30,8 @@
 ;;; Code:
 
 (require 'subr-x)
+(eval-when-compile
+  (require 'helm-source nil t))
 
 (declare-function helm "ext:helm")
 (declare-function helm-marked-candidates "ext:helm")


### PR DESCRIPTION
I've just installed helm-make for the first time today (and it's really nice!) but I had one issue.

When attempting to run it using `M-x helm-make`, I get `invalid-function helm-build-sync-source`. 

I was able to fix it by removing the existing *.elc and adding this section.

Perhaps there is a better solution but I thought I would suggest it. Thank you for making this.