### PR TITLE
use project root instead of current directory by default

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -172,6 +172,8 @@ If it fails to do so, `1' will be returned.
 
 (defvar helm-make--last-item nil)
 
+(defvar-local helm-make--dir nil)
+
 (defun helm--make-action (target)
   "Make TARGET."
   (setq helm-make--last-item target)
@@ -228,7 +230,11 @@ ninja.build file."
   "Call \"make -j ARG target\". Target is selected with completion."
   (interactive "P")
   (let ((makefile (helm--make-makefile-exists
-                   (funcall (cl-find-if 'funcall helm-make-directory-functions-list)))))
+                   (progn
+                     (cl-find-if
+                      (lambda (fn) (setq-local helm-make--dir (funcall fn)))
+                      helm-make-directory-functions-list)
+                     helm-make--dir))))
     (if (not makefile)
         (error "No build file in %s" default-directory)
       (setq helm-make-command (helm--make-construct-command arg makefile))

--- a/helm-make.el
+++ b/helm-make.el
@@ -221,7 +221,9 @@ ninja.build file."
 (defun helm-make (&optional arg)
   "Call \"make -j ARG target\". Target is selected with completion."
   (interactive "P")
-  (let ((makefile (helm--make-makefile-exists default-directory)))
+  (let ((makefile (helm--make-makefile-exists (if (and (fboundp 'project-current) (project-current))
+                                                  (car (project-roots (project-current)))
+                                                default-directory))))
     (if (not makefile)
         (error "No build file in %s" default-directory)
       (setq helm-make-command (helm--make-construct-command arg makefile))


### PR DESCRIPTION
In (not only) latest emacs there is `package.el`. I think it can be useful feature to make in project root by default instead of current directory.