### PR TITLE
Optionally use locate-dominating-file to find Makefile

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -403,6 +403,7 @@ and cache targets of MAKEFILE, if `helm-make-cache-targets' is t."
       (helm
        (require 'helm)
        (helm :sources (helm-build-sync-source "Targets"
+                        :header-name (lambda (name) (format "%s (%s):" name makefile))
                         :candidates 'targets
                         :fuzzy-match helm-make-fuzzy-matching
                         :action 'helm--make-action)

--- a/helm-make.el
+++ b/helm-make.el
@@ -219,13 +219,14 @@ ninja.build file."
             (if (> jobs 0) jobs 1))))
 
 (defcustom helm-make-directory-functions-list
-  '(helm-make-current-directory helm-make-project-directory)
+  '(helm-make-current-directory helm-make-project-directory helm-make-dominating-directory)
   "Functions that return Makefile's directory, sorted by priority."
   :type
   '(repeat
     (choice
      (const :tag "Default directory" helm-make-current-directory)
      (const :tag "Project directory" helm-make-project-directory)
+     (const :tag "Dominating directory with makefile" helm-make-dominating-directory)
      (function :tag "Custom function"))))
 
 ;;;###autoload
@@ -457,6 +458,10 @@ setting the buffer local variable `helm-make-build-dir'."
 (defun helm-make-current-directory()
   "Return the current directory."
   default-directory)
+
+(defun helm-make-dominating-directory ()
+  "Return the dominating directory that contains a Makefile if found"
+  (locate-dominating-file default-directory 'helm--make-makefile-exists))
 
 (provide 'helm-make)
 


### PR DESCRIPTION
I've spent some time working in a project with multiple makefiles where this has been useful. Maybe it is generally useful 🤷‍♂️.

This does two things:
1. Adds an option to `helm-make-directory-functions-list` for finding the "closest" (apparently "dominating" is a term) makefile.
2. Adds a header for helm completion making it clear which makefile we are looking at.