### PR TITLE
Use `makefile` parameter explicitly in `helm--make-target-list-qp`.

### DIFF
--- a/helm-make.el
+++ b/helm-make.el
@@ -266,7 +266,8 @@ ninja.build file."
     (with-temp-buffer
       (insert
        (shell-command-to-string
-        "make -nqp __BASH_MAKE_COMPLETION__=1 .DEFAULT 2>/dev/null"))
+        (format "make -f %s -nqp __BASH_MAKE_COMPLETION__=1 .DEFAULT 2>/dev/null"
+                makefile)))
       (goto-char (point-min))
       (unless (re-search-forward "^# Files" nil t)
         (error "Unexpected \"make -nqp\" output"))


### PR DESCRIPTION
This allows using the function with non-standard Makefile names.